### PR TITLE
Add central quest creation button

### DIFF
--- a/RPGHabitPlanner/Home Screen/HomeView.swift
+++ b/RPGHabitPlanner/Home Screen/HomeView.swift
@@ -97,6 +97,21 @@ struct HomeView: View {
             // Check for damage on app launch
             viewModel.checkForDamageOnAppLaunch()
         }
+        .overlay(alignment: .bottom) {
+            Button {
+                shouldNavigateToQuestCreation = true
+            } label: {
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 56))
+                    .foregroundColor(theme.accentColor)
+                    .background(
+                        Circle()
+                            .fill(theme.backgroundColor)
+                            .frame(width: 64, height: 64)
+                    )
+            }
+            .offset(y: -10)
+        }
         .overlay(
             Group {
                 if showTutorial {


### PR DESCRIPTION
## Summary
- Overlay a plus button centered on the tab bar that opens quest creation

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c4b5f6688331933034a44e40009c